### PR TITLE
Remove invalid dependency in rmw_ecal_shared_cpp.

### DIFF
--- a/rmw_ecal_shared_cpp/package.xml
+++ b/rmw_ecal_shared_cpp/package.xml
@@ -9,7 +9,6 @@
 
  	<build_depend>rmw</build_depend>
   <build_depend>protobuf-dev</build_depend>
-	<build_depend>eCAL</build_depend>
 
 	<depend>rmw_implementation_cmake</depend>
 	<depend>rosidl_generator_c</depend>


### PR DESCRIPTION
Dependency keys for `package.xml` are used by `rosdep` to resolve and install dependencies. Specifically, system keys (non-ROS-packages) are defined [here](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml). The key `eCAL` does not exist and causes `rosdep` to fail to properly resolve dependencies for the `rmw_ecal_shared_cpp` package. Since eCAL is ideally installed as a system package (e.g. to `/usr`) and should be resolvable by CMake if installed, there is no need for this key and it only causes problems.