### PR TITLE
feat: add ecal dependency into package.xml

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -13,29 +13,23 @@ jobs:
       fail-fast: false
       matrix:
         ros_distribution:
-          - foxy
-          - galactic
           - humble
+          - iron
           - rolling
         include:
-          # Foxy Fitzroy
-          - os: ubuntu
-            os_release: focal
-            ros_distribution: foxy
-            ros_version: 2
-          # Galactic Geochelone
-          - os: ubuntu
-            os_release: focal
-            ros_distribution: galactic
-            ros_version: 2
           # Humble Hawksbill
           - os: ubuntu
             os_release: jammy
             ros_distribution: humble
             ros_version: 2
+          # Iron Irwini
+          - os: ubuntu
+            os_release: jammy
+            ros_distribution: iron
+            ros_version: 2
           # Rolling Ridley
           - os: ubuntu
-            os_release: focal
+            os_release: jammy
             ros_distribution: rolling
             ros_version: 2
     container:
@@ -43,26 +37,21 @@ jobs:
     steps:
       - name: install prereqs
         run: apt update && apt install -y sudo curl software-properties-common
-      - name: install eCAL
-        run: |
-          add-apt-repository ppa:ecal/ecal-latest \
-          ; apt-get update \
-          ; apt-get install -y ecal \
       - name: setup directories
         run: mkdir -p ros_ws/src
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ros_ws/src
       - name: setup ROS environment
-        uses: ros-tooling/setup-ros@v0.3
+        uses: ros-tooling/setup-ros@v0.7
         with:
           use-ros2-testing: false
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: rosdep install
         run: "rosdep update && rosdep install -r --from-paths ros_ws/src --ignore-src --rosdistro ${{ matrix.ros_distribution }} -y"
       - name: build
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: rmw_ecal_dynamic_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/rmw_ecal_shared_cpp/package.xml
+++ b/rmw_ecal_shared_cpp/package.xml
@@ -9,6 +9,7 @@
 
  	<build_depend>rmw</build_depend>
   <build_depend>protobuf-dev</build_depend>
+	<build_depend>ecal</build_depend>
 
 	<depend>rmw_implementation_cmake</depend>
 	<depend>rosidl_generator_c</depend>


### PR DESCRIPTION
- add ecal dependency into package.xml because I register ecal into [ros buildfarm](https://index.ros.org/p/ecal/github-eclipse-ecal-ecal/#humble)